### PR TITLE
fix(WebPlugin, copyResources): Correct issue where each file in sources ...

### DIFF
--- a/src/main/scala/com/typesafe/web/sbt/WebPlugin.scala
+++ b/src/main/scala/com/typesafe/web/sbt/WebPlugin.scala
@@ -161,7 +161,7 @@ object WebPlugin extends sbt.Plugin {
     val copyDescs: Seq[(File, File)] = (for {
       source: File <- sources
     } yield {
-      (source ** "*") filter (!_.isDirectory) x Path.rebase(source, target)
+      source filter (!_.isDirectory) pair Path.rebase(source,target)
     }).flatten
     IO.copy(copyDescs)
     copyDescs


### PR DESCRIPTION
...was being used as a globber

Files were being repeatedly copied, leading to a correct directory structure alongside a flattened, all-files-in-basedir structure.

Remove unnecessary call to *\* from yield.

Closes #7
