### PR TITLE
Added tests for runIncremental method

### DIFF
--- a/src/main/scala/com/typesafe/web/sbt/incremental/package.scala
+++ b/src/main/scala/com/typesafe/web/sbt/incremental/package.scala
@@ -124,6 +124,14 @@ package object incremental {
     val prunedOps: Seq[Op] = OpCache.newOrChanged(cache, ops)
     val (results: Map[Op, OpResult], finalResult) = runOps(prunedOps)
 
+    // Check returned results are all within the set of given ops
+    val prunedOpsSet: Set[Op] = prunedOps.to[Set]
+    val resultOpsSet: Set[Op] = results.keySet
+    val unexpectedOps: Set[Op] = resultOpsSet -- prunedOpsSet
+    if (!unexpectedOps.isEmpty) {
+      throw new IllegalArgumentException(s"runOps function returned results for unknown ops: $unexpectedOps")
+    }
+
     // Update the cache with the new information (vacuuming, new results)
     OpCache.cacheResults(cache, results)
     OpCacheIO.toFile(cache, cacheFile)

--- a/src/test/scala/com/typesafe/web/sbt/incremental/IncrementalSpec.scala
+++ b/src/test/scala/com/typesafe/web/sbt/incremental/IncrementalSpec.scala
@@ -308,6 +308,17 @@ class IncrementalSpec extends Specification {
       }
     }
 
+    "fail when runOps gives result for unknown op" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        runIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map[String,OpResult]("op2" -> OpFailure),
+            prunedOps must_== List("op1")
+          )
+        } must throwA[IllegalArgumentException]
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
Added tests to capture the main functional requirements of the runIncremental method.

Now runIncremental also checks that the user's runOps method returns only valid operations (@huntc – this protects against the problem that you had in your code).

```
[info] the runIncremental method should
[info] + always perform an op when there's no cache file
[info] + rerun an op when it failed last time
[info] + skip an op if nothing's changed
[info] + rerun an op when the file it read has changed
[info] + rerun an op when the file it wrote has changed
[info] + rerun an op when the file it wrote has been deleted
[info] + rerun an op when some of the files it read have changed
[info] + rerun an op when some of the files it wrote have changed
[info] + run multiple ops
[info] + vacuum unneeded ops from the cache
[info] + rerun an op if its hash changes
[info] + fail when runOps gives result for unknown op
```
