### PR TITLE
Added no cache OpInputHash result

### DIFF
--- a/src/main/scala/com/typesafe/sbt/web/incremental/OpInputHash.scala
+++ b/src/main/scala/com/typesafe/sbt/web/incremental/OpInputHash.scala
@@ -6,10 +6,20 @@ package com.typesafe.sbt.web.incremental
 import sbt.Hash
 
 /**
+ * The result of hashing the input
+ */
+sealed trait OpInputHashResult
+
+/**
+ * Used to indicate that this operation should not be cached
+ */
+case object NoCache extends OpInputHashResult
+
+/**
  * A hash of an operation's input. Used to check if two operations have the
  * same or different inputs.
  */
-case class OpInputHash(val bytes: Bytes)
+case class OpInputHash(bytes: Bytes) extends OpInputHashResult
 
 /**
  * Factory methods for OpInputHash.
@@ -29,7 +39,7 @@ object OpInputHash {
  * Given an operation, produces a hash of its inputs.
  */
 trait OpInputHasher[Op] {
-  def hash(op: Op): OpInputHash
+  def hash(op: Op): OpInputHashResult
 }
 
 /**
@@ -39,8 +49,12 @@ object OpInputHasher {
   /**
    * Construct an OpInputHash that uses the given hashing logic.
    */
-  def apply[Op](f: Op => OpInputHash): OpInputHasher[Op] = new OpInputHasher[Op] {
+  def apply[Op](f: Op => OpInputHashResult): OpInputHasher[Op] = new OpInputHasher[Op] {
     def hash(op: Op) = f(op)
+  }
+
+  def noCache[Op]: OpInputHasher[Op] = new OpInputHasher[Op] {
+    def hash(op: Op) = NoCache
   }
 }
 

--- a/src/test/scala/com/typesafe/web/sbt/incremental/IncrementalSpec.scala
+++ b/src/test/scala/com/typesafe/web/sbt/incremental/IncrementalSpec.scala
@@ -308,6 +308,26 @@ class IncrementalSpec extends Specification {
       }
     }
 
+    "rerun an op if the op hasher returns NoCache" in {
+      IO.withTemporaryDirectory { tmpDir =>
+
+        implicit val hasher = OpInputHasher.noCache[String]
+
+        runIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set.empty, filesWritten = Set.empty)),
+            prunedOps must_== List("op1")
+            )
+        }
+        runIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set.empty, filesWritten = Set.empty)),
+            prunedOps must_== List("op1")
+            )
+        }
+      }
+    }
+
     "fail when runOps gives result for unknown op" in {
       IO.withTemporaryDirectory { tmpDir =>
         runIncremental(tmpDir, List("op1")) { prunedOps =>


### PR DESCRIPTION
The OpInputHasher now produces an OpInputHashResult, which can either be an
OpInputHash, or NoCache.  NoCache instructs the incremental operation API not
to cache this operation, nor to consult the cache when determining whether
this operation should be done or not.
