### PR TITLE
Add compile, test and sourceDirectories settings

### DIFF
--- a/src/main/scala/com/typesafe/sbt/web/SbtWebPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWebPlugin.scala
@@ -92,6 +92,8 @@ object SbtWebPlugin extends sbt.Plugin {
 
     sourceDirectory in Assets := (sourceDirectory in Compile).value / "assets",
     sourceDirectory in TestAssets := (sourceDirectory in Test).value / "assets",
+    sourceDirectories in Assets := (unmanagedSourceDirectories in Assets).value,
+    sourceDirectories in TestAssets := (unmanagedSourceDirectories in TestAssets).value,
 
     jsFilter in Assets := GlobFilter("*.js"),
     jsFilter in TestAssets := GlobFilter("*Test.js") | GlobFilter("*Spec.js"),
@@ -101,8 +103,20 @@ object SbtWebPlugin extends sbt.Plugin {
     resourceManaged in Assets := target.value / "public",
     resourceManaged in TestAssets := target.value / "public-test",
 
+    // Stub compile tasks
+    compile in Assets := inc.Analysis.Empty,
+    compile in TestAssets := inc.Analysis.Empty,
+    compile in TestAssets <<= (compile in TestAssets).dependsOn(compile in Assets),
+
+    // Stub test task
+    test in TestAssets := (),
+    test in TestAssets <<= (test in TestAssets).dependsOn(compile in TestAssets),
+
+    compile in Compile <<= (compile in Compile).dependsOn(compile in Assets),
+    compile in Test <<= (compile in Test).dependsOn(compile in TestAssets),
     copyResources in Compile <<= (copyResources in Compile).dependsOn(copyResources in Assets),
     copyResources in Test <<= (copyResources in Test).dependsOn(copyResources in TestAssets),
+    test in Test <<= (test in Test).dependsOn(test in TestAssets),
 
     watchSources <++= unmanagedSources in Assets,
     watchSources <++= unmanagedSources in TestAssets,


### PR DESCRIPTION
Move some common settings into sbt-web. The test and compile tasks give support for invoking Assets/TestAssets task's compilation via `compile`, `test:compile`, `web-assets:compile`, `web-assets-test:compile`, `test`, `web-assets-test:test`, etc.

Tasks only need to add a single setting, e.g.

``` scala
  val unscopedSettings: Seq[Setting[_]] = Seq(
    compile <<= compile.dependsOn(coffeeScript),
```

I also added `sourceDirectories` so we can have more than one input directory for our tasks, but maybe that's something that doesn't matter. By the way, I think you might be able to get all sorts of default values and directory bindings automatically from `sbt.Defaults`, e.g. `inConfig(Assets)(Defaults.sourceConfigPaths)` would set up default values for `sourceDirectories` which you could then override.
