### PR TITLE
Ensure test webjars don't include compile webjars

### DIFF
--- a/src/sbt-test/sbt-web/extract-web-jars/build.sbt
+++ b/src/sbt-test/sbt-web/extract-web-jars/build.sbt
@@ -3,5 +3,6 @@ webSettings
 libraryDependencies ++= Seq(
   "org.webjars" % "jquery" % "2.0.3-1",
   "org.webjars" % "prototype" % "1.7.1.0",
-  "org.webjars" % "less-node" % "1.6.0-1"
+  "org.webjars" % "less-node" % "1.6.0-1",
+  "org.webjars" % "requirejs" % "2.1.11-1" % "test"
 )

--- a/src/sbt-test/sbt-web/extract-web-jars/test
+++ b/src/sbt-test/sbt-web/extract-web-jars/test
@@ -2,6 +2,7 @@
 > assets
 $ exists target/web/public/main/lib/jquery/jquery.js
 $ exists target/web/public/main/lib/prototype/prototype.js
+-$ exists target/web/public/main/lib/requirejs/require.js
 
 # Extract node modules
 > web-assets:web-node-modules
@@ -20,3 +21,17 @@ $ sleep 1
 # jquery.js should not have been re-extracted, assert that it is older
 $ newer target/foo target/web/public/main/lib/jquery/jquery.js
 
+> clean
+
+# Test assets
+> web-assets-test:assets
+
+# First check that test webjars and only test webjars were extracted
+$ exists target/web/web-modules/test/webjars/lib/requirejs/require.js
+-$ exists target/web/web-modules/test/webjars/lib/jquery/jquery.js
+-$ exists target/web/web-modules/test/webjars/lib/prototype/prototype.js
+
+# Now check everything was aggregated in test assets
+$ exists target/web/public/test/lib/jquery/jquery.js
+$ exists target/web/public/test/lib/prototype/prototype.js
+$ exists target/web/public/test/lib/requirejs/require.js


### PR DESCRIPTION
Previously, web-assets-test:web-jars was extracting both test webjars and compile webjars.  This then caused a mapping error when they were copied to the test assets target directory, because the same destination files appeared twice with two different sources.  This ensures that web-assets-test:web-jars only extracts the test scoped web-jars.
