### PR TITLE
Stage task

### DIFF
--- a/src/sbt-test/sbt-web/asset-pipeline/build.sbt
+++ b/src/sbt-test/sbt-web/asset-pipeline/build.sbt
@@ -30,13 +30,4 @@ jsmin := { (mappings: Seq[PathMapping]) =>
   minMappings ++ other
 }
 
-stages <+= jsmin
-
-val check = taskKey[Unit]("check the pipeline mappings")
-
-check := {
-  val mappings = pipeline.value
-  val paths = (mappings map (_._2)).toSet
-  val expected = Set("js", "js/all.min.js", "coffee", "coffee/a.coffee")
-  if (paths != expected) sys.error(s"Expected $expected but pipeline paths are $paths")
-}
+pipelineStages <+= jsmin

--- a/src/sbt-test/sbt-web/asset-pipeline/test
+++ b/src/sbt-test/sbt-web/asset-pipeline/test
@@ -1,1 +1,3 @@
-> check
+> web-stage
+$ exists target/web/stage/js/all.min.js
+$ exists target/web/stage/coffee/a.coffee


### PR DESCRIPTION
Incorporated a stage task in a similar fashion to that of the sbt-native-packager. This task performs the asset pipeline delivering its mappings to a target/web/stage folder.

In so doing the scripted test has been simplified by incorporating the stage command.
