### PR TITLE
Put JavaScript resources inside packages

### DIFF
--- a/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
@@ -307,17 +307,12 @@ object SbtWeb extends AutoPlugin {
    * The resource won't be copied if the new file is older.
    *
    * @param to the target folder.
-   * @param name the name of the resource.
-   * @param classLoader the class loader to use.
+   * @param url the url of the resource.
    * @param cacheDir the dir to cache whether the file was read or not.
    * @return the copied file.
    */
-  def copyResourceTo(to: File, name: String, classLoader: ClassLoader, cacheDir: File): File = {
-    val url = classLoader.getResource(name)
-    if (url == null) {
-      throw new IllegalArgumentException("Couldn't find " + name)
-    }
-    val toFile = to / name
+  def copyResourceTo(to: File, url: URL, cacheDir: File): File = {
+    val toFile = to / new File(url.toURI).getName
 
     incremental.runIncremental(cacheDir, Seq(url)) {
       urls =>


### PR DESCRIPTION
Raising an issue, as suggested [here](https://github.com/sbt/sbt-coffeescript-plugin/pull/1/files#r10447712):

> I think it would be nice if `coffee.js` was inside `src/main/resources/com/typesafe/…`. somewhere.
