### PR TITLE
Modified incremental compiler to delete old files

### DIFF
--- a/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
@@ -383,7 +383,7 @@ object SbtWeb extends AutoPlugin {
    * @return the copied file.
    */
   def copyResourceTo(to: File, url: URL, cacheDir: File): File = {
-    incremental.runIncremental(cacheDir, Seq(url)) {
+    incremental.syncIncremental(cacheDir, Seq(url)) {
       ops =>
         val fromFile = if (url.getProtocol == "file") {
           new File(url.toURI)
@@ -405,7 +405,7 @@ object SbtWeb extends AutoPlugin {
         } else {
           (Map.empty[URL, OpResult], toFile)
         }
-    }
+    }._2
   }
 
   // Actor system management and API

--- a/src/main/scala/com/typesafe/sbt/web/incremental/package.scala
+++ b/src/main/scala/com/typesafe/sbt/web/incremental/package.scala
@@ -4,9 +4,6 @@
 package com.typesafe.sbt.web
 
 import java.io.File
-import sbt.{ FeedbackProvidedException, LoggerReporter }
-import sbt.Keys.TaskStreams
-import xsbti.{ CompileFailed, Problem, Severity }
 
 /**
  * The incremental task API lets tasks run more quickly when they are
@@ -110,6 +107,7 @@ package object incremental {
    * Callers must provide an implicit OpInputHasher so that the API can
    * distinguish different operations’ parameters.
    */
+  @deprecated("Use syncIncremental to ensure old products are deleted", "1.0.1")
   def runIncremental[Op,A](
       cacheDirectory: File, ops: Seq[Op])(
       runOps: Seq[Op] => (Map[Op, OpResult], A))(
@@ -137,6 +135,124 @@ package object incremental {
     OpCacheIO.toFile(cache, cacheFile)
 
     finalResult
+  }
+
+  /**
+   * Syncs operations that haven't been run before. This method is the main
+   * interface to the incremental API.
+   *
+   * This method will delete products under the following conditions:
+   *  * If the an op from a previous run doesn't exist in the current run,
+   *    all of its products that weren't produced by other ops in the
+   *    previous run or ops from the current run will be deleted.
+   *  * If an op produced a product in a previous run, but didn't produce
+   *    it in the current run, and no other op produced it, it will be
+   *    deleted.
+   *
+   * @tparam Op The Op type parameter gives the type of the individual
+   * operations. There are no restrictions on which type callers
+   * should use here. The runIncremental method treats Op as a
+   * completely opaque type. The caller can use whatever abstract
+   * representation of operations is most convenient; functions,
+   * strings, custom classes, etc are all possible. The only
+   * requirement is that the caller must provide two arguments to
+   * allow runIncremental to work with operations: runOps to run a
+   * sequence of operations and return the operations’ results and
+   * inputHasher to get a hash of an operation’s inputs.
+   *
+   * @tparam A The A type parameter gives the return type of the
+   * runIncremental method. The runOps method returns a value of type
+   * A and this value is then returned by the runIncremental method.
+   *
+   * @param cacheDirectory A parent directory for a cache file that
+   *                       will be used for caching information between
+   *                       invocations.
+   *
+   * @param ops The ops parameter is a list of possible operations to
+   * perform. The runIncremental method will prune this list and call
+   * the run parameter with the pruned list.
+   *
+   * @param runOps The runOps function returns a (Map[Op,OpResult],A).
+   * The Map[Op,OpResult] is used to update the cache of operations.
+   * The A value is used by runIncremental as its return value for
+   * runIncremental method.
+   *
+   * Each OpResult can be either an OpSuccess or an OpFailure. If an
+   * operation succeeded, it should return the paths of any files it read
+   * from or wrote to.
+   *
+   * Example OpResults:
+   * - Read 1 file, no output file
+   *   {{{OpSuccess(filesRead = Set(sourceFile), filesWritten = Set.empty)}}}
+   * - Read 1 file, wrote 1 file
+   *   {{{OpSuccess(filesRead = Set(sourceFile), filesWritten = Set(targetFile))}}}
+   * - Read 3 files, wrote 2 files
+   *   {{{OpSuccess(filesRead = Set(a, b, c), filesWritten = Set(d, e))}}}
+   * - Failed with 1 problem
+   *   {{{OpFailure}}}
+   * - Failed with a problem, but without any details
+   *   {{{OpFailure}}}
+   * - An unexpected error which doesn’t need to be displayed to the user
+   *   in a special way
+   *   {{{throw new DecodeException(“Couldn’t compile: failed to decode ”)}}}
+   *
+   * @param inputHasher The inputHasher implicit parameter lets the runIncremental
+   * method distinguish between operations’ input parameters. In addition to
+   * reading and writing files, operations usually take input
+   * parameters, for example compilation settings. The incremental API
+   * doesn’t need to know the content of these parameters, but it does
+   * need to be able to tell if parameters are the same or different.
+   * Callers must provide an implicit OpInputHasher so that the API can
+   * distinguish different operations’ parameters.
+   *
+   * @return A tuple of all the output files, including those that were
+   *         produced by a previous run and didn't need to be re run, and
+   *         the result of the runOps method.
+   */
+  def syncIncremental[Op,A](
+                            cacheDirectory: File, ops: Seq[Op])(
+                            runOps: Seq[Op] => (Map[Op, OpResult], A))(
+                            implicit inputHasher: OpInputHasher[Op]): (Set[File], A) = {
+    // Load the cache from a file in the current task's cache directory
+    val cacheFile: File = new File(cacheDirectory, "op-cache")
+    val cache: OpCache = OpCacheIO.fromFile(cacheFile)
+
+    // Before vacuuming the cache, find out what the old cache had produced
+    val allOldProducts = cache.content.values.to[Set].flatMap(_.products)
+
+    // Clear out any unknown operations from the existing cache
+    OpCache.vacuumExcept(cache, ops)
+
+    // Work out the minimal set of ops we need to run and run them
+    val prunedOps: Seq[Op] = OpCache.newOrChanged(cache, ops)
+    val (results: Map[Op, OpResult], finalResult) = runOps(prunedOps)
+
+    // Check returned results are all within the set of given ops
+    val prunedOpsSet: Set[Op] = prunedOps.to[Set]
+    val resultOpsSet: Set[Op] = results.keySet
+    val unexpectedOps: Set[Op] = resultOpsSet -- prunedOpsSet
+    if (!unexpectedOps.isEmpty) {
+      throw new IllegalArgumentException(s"runOps function returned results for unknown ops: $unexpectedOps")
+    }
+
+    // Work out what the current valid products are
+    val opsSet: Set[Op] = ops.to[Set]
+    val oldProductsToKeep = OpCache.productsForOps(cache, opsSet -- prunedOpsSet)
+    val newProducts = results.values.to[Set].flatMap {
+      case OpFailure => Set.empty[File]
+      case OpSuccess(_, products) => products
+    }
+    val currentProducts = oldProductsToKeep ++ newProducts
+
+    // Delete all products that weren't produced by previous non expired ops, or by the current run
+    val productsToDelete = allOldProducts -- currentProducts
+    productsToDelete.filterNot(_.isDirectory).foreach(_.delete())
+
+    // Update the cache with the new information (vacuuming, new results)
+    OpCache.cacheResults(cache, results)
+    OpCacheIO.toFile(cache, cacheFile)
+
+    (currentProducts, finalResult)
   }
 
   /**

--- a/src/test/scala/com/typesafe/sbt/web/incremental/IncrementalSpec.scala
+++ b/src/test/scala/com/typesafe/sbt/web/incremental/IncrementalSpec.scala
@@ -9,6 +9,8 @@ import _root_.sbt.IO
 @RunWith(classOf[JUnitRunner])
 class IncrementalSpec extends Specification {
 
+  sequential
+
   "the runIncremental method" should {
 
     "always perform an op when there's no cache file" in {
@@ -316,6 +318,422 @@ class IncrementalSpec extends Specification {
             prunedOps must_== List("op1")
           )
         } must throwA[IllegalArgumentException]
+      }
+    }
+
+  }
+
+  "the syncIncremental method" should {
+
+    "always perform an op when there's no cache file" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map[String,OpResult]("op1" -> OpFailure),
+            prunedOps must_== List("op1")
+            )
+        }._2
+      }
+    }
+
+    "rerun an op when it failed last time" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpFailure),
+            prunedOps must_== List("op1")
+            )
+        }
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpFailure),
+            prunedOps must_== List("op1")
+            )
+        }._2
+      }
+    }
+
+    "skip an op if nothing's changed" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val file1 = new File(tmpDir, "1")
+        IO.write(file1, "x")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set())),
+            prunedOps must_== List("op1")
+            )
+        }
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps must_== List()
+            )
+        }._2
+      }
+    }
+
+    "rerun an op when the file it read has changed" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val file1 = new File(tmpDir, "1")
+        IO.write(file1, "x")
+        val file2 = new File(tmpDir, "2")
+        IO.write(file1, "x")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set(file2))),
+            prunedOps must_== List("op1")
+            )
+        }
+
+        IO.write(file1, "y")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps must_== List("op1")
+            )
+        }._2
+      }
+    }
+
+    "rerun an op when the file it wrote has changed" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val file1 = new File(tmpDir, "1")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(), filesWritten = Set(file1))),
+            prunedOps must_== List("op1")
+            )
+        }
+
+        IO.write(file1, "y")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps must_== List("op1")
+            )
+        }._2
+      }
+    }
+
+    "rerun an op when the file it wrote has been deleted" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val file1 = new File(tmpDir, "1")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(), filesWritten = Set(file1))),
+            prunedOps must_== List("op1")
+            )
+        }
+
+        IO.delete(file1)
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps must_== List("op1")
+            )
+        }._2
+      }
+    }
+
+    "rerun an op when some of the files it read have changed" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        IO.write(file1, "x")
+        IO.write(file2, "x")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1, file2), filesWritten = Set())),
+            prunedOps must_== List("op1")
+            )
+        }
+
+        IO.write(file2, "y")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps must_== List("op1")
+            )
+        }._2
+      }
+    }
+
+    "rerun an op when some of the files it wrote have changed" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          IO.write(file2, "x")
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(), filesWritten = Set(file1, file2))),
+            prunedOps must_== List("op1")
+            )
+        }
+
+        IO.write(file2, "y")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps must_== List("op1")
+            )
+        }._2
+      }
+    }
+
+    "run multiple ops" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        val file3 = new File(tmpDir, "3")
+        val file4 = new File(tmpDir, "4")
+        IO.write(file1, "x")
+        IO.write(file2, "x")
+        IO.write(file3, "x")
+        IO.write(file4, "x")
+
+        syncIncremental(tmpDir, List("op1", "op2", "op3", "op4")) { prunedOps =>
+          (
+            Map(
+              "op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set()),
+              "op2" -> OpSuccess(filesRead = Set(file2), filesWritten = Set(file3)),
+              "op3" -> OpSuccess(filesRead = Set(), filesWritten = Set(file4)),
+              "op4" -> OpFailure
+            ),
+            prunedOps must_== List("op1", "op2", "op3", "op4")
+            )
+        }
+
+        IO.write(file1, "y")
+        IO.write(file4, "y")
+
+        syncIncremental(tmpDir, List("op1", "op2", "op3", "op4")) { prunedOps =>
+          (
+            Map(
+              "op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set()),
+              "op3" -> OpSuccess(filesRead = Set(), filesWritten = Set(file4)),
+              "op4" -> OpFailure
+            ),
+            prunedOps must_== List("op1", "op3", "op4")
+            )
+        }._2
+      }
+    }
+
+    "vacuum unneeded ops from the cache" in {
+      IO.withTemporaryDirectory { tmpDir =>
+
+      // Create an empty cache
+        syncIncremental(tmpDir, List[String]()) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps must_== List()
+            )
+        }
+
+        val cacheFile = new File(tmpDir, "op-cache")
+        val emptyCacheFileLength = cacheFile.length()
+
+        val file1 = new File(tmpDir, "1")
+        IO.write(file1, "x")
+
+        // Run with a successful op that will be cached
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set())),
+            prunedOps must_== List("op1")
+            )
+        }
+
+        cacheFile.length() must_!= emptyCacheFileLength
+
+        // Run with different set of ops - should vacuum old ops
+
+        syncIncremental(tmpDir, List("op9")) { prunedOps =>
+          (
+            Map("op9" -> OpFailure),
+            prunedOps must_== List("op9")
+            )
+        }
+
+        // Check cache file is empty again, i.e. op1 has been vacuumed
+
+        cacheFile.length() must_== emptyCacheFileLength
+
+      }
+    }
+
+    "rerun an op if its hash changes" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        IO.write(file1, "x")
+        IO.write(file2, "x")
+
+        var hashPrefix = ""
+        implicit val hasher = OpInputHasher[String](op => OpInputHash.hashString(hashPrefix + op))
+
+        // Cache ops with an initial hash prefix
+
+        hashPrefix = "1/"
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set(file2))),
+            prunedOps must_== List("op1")
+            )
+        }
+
+        // No ops should run because we leave the hash prefix the same
+
+        hashPrefix = "1/"
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map(),
+            prunedOps must_== List()
+            )
+        }
+
+        // All ops should run again because we changed the hash prefix
+
+        hashPrefix = "2/"
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set(file2))),
+            prunedOps must_== List("op1")
+            )
+        }._2
+      }
+    }
+
+    "fail when runOps gives result for unknown op" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map[String,OpResult]("op2" -> OpFailure),
+            prunedOps must_== List("op1")
+            )
+        } must throwA[IllegalArgumentException]
+      }
+    }
+
+    "delete a file if a previous op has been removed" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+
+        syncIncremental(tmpDir, List("op1", "op2")) { prunedOps =>
+          IO.write(file1, "x")
+          IO.write(file2, "x")
+          (
+            Map[String,OpResult](
+              "op1" -> OpSuccess(Set.empty, Set(file1)),
+              "op2" -> OpSuccess(Set.empty, Set(file2))
+            ),
+            Unit
+            )
+        }
+        val (outputFiles, _) = syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map.empty[String,OpResult],
+            prunedOps must beEmpty
+          )
+        }
+
+        outputFiles must_== Set(file1)
+
+        file1.exists must beTrue
+        file2.exists must beFalse
+      }
+    }
+
+    "delete a file if it's no longer produced by an op" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val infile = new File(tmpDir, "in")
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+
+        IO.write(infile, "1")
+
+        syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          IO.write(file2, "x")
+          (
+            Map[String,OpResult](
+              "op1" -> OpSuccess(Set(infile), Set(file1, file2))
+            ),
+            Unit
+            )
+        }
+
+        IO.write(infile, "2")
+
+        val (outputFiles, _) = syncIncremental(tmpDir, List("op1")) { prunedOps =>
+          (
+            Map[String,OpResult](
+              "op1" -> OpSuccess(Set(infile), Set(file1))
+            ),
+            prunedOps must_== List("op1")
+            )
+        }
+
+        outputFiles must_== Set(file1)
+
+        file1.exists must beTrue
+        file2.exists must beFalse
+      }
+    }
+
+    "not delete a file if it's produced by another op" in {
+      IO.withTemporaryDirectory { tmpDir =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        val infile = new File(tmpDir, "in")
+
+        syncIncremental(tmpDir, List("op1", "op2")) { prunedOps =>
+          IO.write(file1, "x")
+          IO.write(file2, "x")
+          (
+            Map[String,OpResult](
+              "op1" -> OpSuccess(Set(infile), Set(file1)),
+              "op2" -> OpSuccess(Set.empty, Set(file2))
+            ),
+            Unit
+            )
+        }
+
+        IO.write(infile, "2")
+
+        val (outputFiles, _) = syncIncremental(tmpDir, List("op1", "op3")) { prunedOps =>
+          (
+            Map[String,OpResult](
+              "op1" -> OpSuccess(Set(infile), Set.empty),
+              "op3" -> OpSuccess(Set.empty, Set(file1, file2))
+            ),
+            Unit
+            )
+        }
+
+        outputFiles must_== Set(file1, file2)
+
+        file1.exists must beTrue
+        file2.exists must beTrue
       }
     }
 


### PR DESCRIPTION
Also incremental compiler now produces a list of all products including those
from previous compiles, making it much easier to use with SBT tasks that
expect all products, not just the ones that were incrementally compiled, to
be returned.
