### PR TITLE
Use sbt-release plugin for release management

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,6 @@ organization := "com.typesafe.sbt"
 
 name := "sbt-web"
 
-version := "1.0.3-SNAPSHOT"
-
 scalaVersion := "2.10.4"
 
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")

--- a/release.sbt
+++ b/release.sbt
@@ -1,0 +1,31 @@
+import sbtrelease._
+import ReleaseStateTransformations._
+import ReleaseKeys._
+
+releaseSettings
+
+lazy val scriptedKey = taskKey[Unit]("scripted")
+
+scriptedKey := {
+  val log = streams.value.log
+  log.info("Executing scripted...")
+  val _ = scripted.toTask("").value
+  log.info("...scripted Done!")
+}
+
+lazy val runScripted: ReleaseStep = releaseTask(scriptedKey in ThisProject)
+
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  runScripted,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  publishArtifacts,
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
+)

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "1.0.3-SNAPSHOT"


### PR DESCRIPTION
Use [sbt-release](https://github.com/sbt/sbt-release) plugin to automate future releases. I couldn't test it out completely as I've got no access to publish plugins, esp. sbt-web.

To fire it up, use `sbt release`. Not sure if there's a test run, but it could be tested for the upcoming release(s). It worked for me for another sbt project, but without publishing to remote repositories. Worth to give it a shot anyway.
