### PR TITLE
Add sbt-filter to list of available plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following is a list of plugins we know of that are built on sbt-web:
 * [sbt-css-compress](https://github.com/ground5hark/sbt-css-compress#sbt-css-compress)
 * [sbt-digest](https://github.com/sbt/sbt-digest#sbt-digest)
 * [sbt-dustjs-linkedin](https://github.com/jmparsons/sbt-dustjs-linkedin)
+* [sbt-filter](https://github.com/rgcottrell/sbt-filter)
 * [sbt-gzip](https://github.com/sbt/sbt-gzip#sbt-gzip)
 * [sbt-html-minifier](https://github.com/rgcottrell/sbt-html-minifier)
 * [sbt-imagemin](https://github.com/rgcottrell/sbt-imagemin)


### PR DESCRIPTION
This is pretty much the simplest filter possible, but is useful for keeping certain files out of the final asset build.
