### PR TITLE
Fix packaging for empty package prefix

### DIFF
--- a/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
@@ -302,12 +302,12 @@ object SbtWeb extends AutoPlugin {
    */
   def packageMappings = Def.task {
     val webjar = packageAsWebJar.value
-    val webjarPrefix = s"${WEBJARS_PATH_PREFIX}/${normalizedName.value}/${version.value}"
+    val webjarPrefix = s"${WEBJARS_PATH_PREFIX}/${normalizedName.value}/${version.value}/"
     val prefix = if (webjar) webjarPrefix else packagePrefix.value
     val exclude = if (webjar) Some(webModulesLib.value) else None
     (pipeline in Defaults.ConfigGlobal).value flatMap {
       case (file, path) if exclude.fold(false)(path.startsWith) => None
-      case (file, path) => Some(file -> s"$prefix/$path")
+      case (file, path) => Some(file -> (prefix + path))
     }
   }
 

--- a/src/sbt-test/sbt-web/package/build.sbt
+++ b/src/sbt-test/sbt-web/package/build.sbt
@@ -8,6 +8,4 @@ crossPaths := false
 
 libraryDependencies += "org.webjars" % "jquery" % "2.0.3-1"
 
-WebKeys.packagePrefix in Assets := "public"
-
 TaskKey[Unit]("extractAssets") := IO.unzip((artifactPath in (Assets, packageBin)).value, file("extracted"))

--- a/src/sbt-test/sbt-web/package/test
+++ b/src/sbt-test/sbt-web/package/test
@@ -2,5 +2,13 @@
 $ exists target/web-project-0.1-web-assets.jar
 
 > extractAssets
+$ exists extracted/js/a.js
+$ exists extracted/lib/jquery/jquery.js
+
+> 'set WebKeys.packagePrefix in Assets := "public/"'
+> web-assets:package
+
+$ delete extracted
+> extractAssets
 $ exists extracted/public/js/a.js
 $ exists extracted/public/lib/jquery/jquery.js


### PR DESCRIPTION
I broke this when extending with the webjar packaging.

An empty package prefix was creating package paths starting at root with `/`. It wasn't making any difference to sbt's `IO.unzip` but `jar xf` does try to unzip to the root directory with these paths. Revert back to the prefix simply concatenated on front, with trailing `/` expected.
