### PR TITLE
Add sbt-emberjs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following is a list of plugins we know of that are built on sbt-web:
 * [sbt-css-compress](https://github.com/ground5hark/sbt-css-compress#sbt-css-compress)
 * [sbt-digest](https://github.com/sbt/sbt-digest#sbt-digest)
 * [sbt-dustjs-linkedin](https://github.com/jmparsons/sbt-dustjs-linkedin)
+* [sbt-emberjs](https://github.com/dwickern/sbt-emberjs)
 * [sbt-filter](https://github.com/rgcottrell/sbt-filter)
 * [sbt-gzip](https://github.com/sbt/sbt-gzip#sbt-gzip)
 * [sbt-handlebars](https://github.com/Amadeus82/sbt-handlebars)


### PR DESCRIPTION
If you will have it, this plugin compiles ember.js templates (a special flavor of handlebars) into javascript assets.
