### PR TITLE
#106. use bintray-sbt 0.3.0-93126a

### DIFF
--- a/bintray.sbt
+++ b/bintray.sbt
@@ -1,0 +1,2 @@
+bintrayOrganization := Some("sbt-web")
+bintrayRepository := "sbt-plugin-releases"

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-import bintray.Keys._
-
 organization := "com.typesafe.sbt"
 name := "sbt-web"
 description := "sbt web support"
+homepage := Some(url("https://github.com/sbt/sbt-web"))
+licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
 sbtPlugin := true
 scalaVersion := "2.10.4"
@@ -20,11 +20,3 @@ resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 scriptedSettings
 scriptedLaunchOpts += "-Dproject.version=" + version.value
-
-// Publish settings
-bintrayPublishSettings
-publishMavenStyle := false
-bintrayOrganization in bintray := Some("sbt-web")
-repository in bintray := "sbt-plugin-releases"
-homepage := Some(url("https://github.com/sbt/sbt-web"))
-licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.eed3si9n" % "bintray-sbt" % "0.3.0-93126a5d02f296a4e460e264ecb62b28046aeef1")
+resolvers += Resolver.url("bintray-eed3si9n-sbt-plugins", url("https://dl.bintray.com/eed3si9n/sbt-plugins/"))(Resolver.ivyStylePatterns)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
+// addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
-// addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
Fixes the community build issue described in #106.

This uses temporarily forked bintray-sbt that is auto plugin and separates publish (staging) and releasing.
If publishTo is rewired, publish should work without the credential file.
