### PR TITLE
Bump sbt version to 0.13.8 in sbt-web-tester

### DIFF
--- a/sbt-web-tester/project/build.properties
+++ b/sbt-web-tester/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8


### PR DESCRIPTION
This prevents the following error during parsing of the root *build.sbt*:

```
sbt-web/build.sbt:12: error: eof expected but ';' found.
resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
```