### PR TITLE
Make plugins node modules a build setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
-jdk: openjdk7
+jdk: oraclejdk7
 language: scala
 script: sbt test scripted


### PR DESCRIPTION
Fixes #130

By making it a build setting, it only gets executed once per build, instead of once per project.  I've tested this with sbt-js-engine to make sure it works.

Also fixed a small bug in copying a resource, where the name of the resource file would end up being the name of the jar file it was extracted from, not the resource file.  eg, the extracted stylus script would be called sbt-stylus-1.0.jar instead of stylus.js.

Review by @huntc and @pvlugter.