### PR TITLE
Workaround for inter-project dependency tracking

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/src/main/scala/com/typesafe/sbt/web/CompatKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/web/CompatKeys.scala
@@ -1,0 +1,9 @@
+package com.typesafe.sbt.web
+
+import sbt._
+import sbt.Keys.Classpath
+
+object CompatKeys {
+  val exportedProductsIfMissing = TaskKey[Classpath]("exported-products-if-missing", "Build products that go on the exported classpath if missing.")
+  val exportedProductsNoTracking = TaskKey[Classpath]("exported-products-no-tracking", "Just the exported classpath without triggering the compilation.")
+}

--- a/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
@@ -331,8 +331,9 @@ object SbtWeb extends AutoPlugin {
     }
   }
 
-  def exportAssets(assetConf: Configuration, exportConf: Configuration) = Def.task {
-    if ((exportJars in exportConf).value) Seq.empty else (exportedProducts in assetConf).value
+  def exportAssets(assetConf: Configuration, exportConf: Configuration): Def.Initialize[Task[Classpath]] = Def.taskDyn {
+    if ((exportJars in exportConf).value) Def.task { Seq.empty }
+    else (exportedProducts in assetConf)
   }
 
   def packageSettings: Seq[Setting[_]] = inConfig(Assets)(

--- a/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
@@ -203,7 +203,30 @@ object SbtWeb extends AutoPlugin {
     mappings in (Test, packageBin) ++= (exportedMappings in TestAssets).value,
     exportedProducts in Compile ++= exportAssets(Assets, Compile).value,
     exportedProducts in Test ++= exportAssets(TestAssets, Test).value,
-
+    CompatKeys.exportedProductsIfMissing in Compile := {
+      ((CompatKeys.exportedProductsIfMissing in Compile).?).value match {
+        case Some(x) => x ++ exportAssets(Assets, Compile).value
+        case None    => Nil
+      }
+    },
+    CompatKeys.exportedProductsIfMissing in Test := {
+      ((CompatKeys.exportedProductsIfMissing in Test).?).value match {
+        case Some(x) => x ++ exportAssets(TestAssets, Test).value
+        case None    => Nil
+      }
+    },
+    CompatKeys.exportedProductsNoTracking in Compile := {
+      ((CompatKeys.exportedProductsNoTracking in Compile).?).value match {
+        case Some(x) => x ++ exportAssets(Assets, Compile).value
+        case None    => Nil
+      }
+    },
+    CompatKeys.exportedProductsNoTracking in Test := {
+      ((CompatKeys.exportedProductsNoTracking in Test).?).value match {
+        case Some(x) => x ++ exportAssets(TestAssets, Test).value
+        case None    => Nil
+      }
+    },
     compile in Assets := inc.Analysis.Empty,
     compile in TestAssets := inc.Analysis.Empty,
     compile in TestAssets <<= (compile in TestAssets).dependsOn(compile in Assets),

--- a/src/sbt-test/sbt-web/multi-module/project/build.properties
+++ b/src/sbt-test/sbt-web/multi-module/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.10-RC2


### PR DESCRIPTION
This is a half of fix for sbt/sbt#2427. The other half is sbt/sbt#2443.

sbt-web uses `exportedProducts in Compile` and `exportedProducts in Test` as the extension point for the assets. The problem is that sbt 0.13.10 defines a few internal keys that bypasses the `exportedProducts`. This change works around that.

Another change that was added turns `exportAssets` into a dynamic task so `exportedProducts` is not invoked if it's not necessary.