### PR TITLE
Started working on supporting sbt 1.0 cross building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
-jdk: oraclejdk7
+jdk: oraclejdk8
 language: scala
-script: sbt test scripted
+script: sbt ^test ^scripted

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,15 @@
 jdk: oraclejdk8
 language: scala
 script: sbt ^test ^scripted
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    
+before_cache:
+  # Delete the cached artifacts
+  - rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.typesafe.sbt/sbt-web
+  # Delete all ivydata files
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
+

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,10 @@ lazy val `sbt-web` = project in file(".")
 description := "sbt web support"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.3.16",
+  "com.typesafe.akka" %% "akka-actor" % (scalaBinaryVersion.value match {
+    case "2.10" => "2.3.16"
+    case _ => "2.5.4"
+  }),
   "org.webjars" % "webjars-locator-core" % "0.32",
   "org.specs2" %% "specs2-core" % "3.8.9" % "test",
   "junit" % "junit" % "4.12" % "test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-web-build-base" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-web-build-base" % "1.1.0")

--- a/sbt-web-tester/project/build.properties
+++ b/sbt-web-tester/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=1.0.0

--- a/sbt-web-tester/project/build.properties
+++ b/sbt-web-tester/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0
+sbt.version=0.13.16

--- a/src/main/scala-sbt-0.13/com/typesafe/sbt/web/Compat.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbt/web/Compat.scala
@@ -1,0 +1,22 @@
+package com.typesafe.sbt.web
+
+import akka.actor.ActorSystem
+import sbt._
+
+object Compat {
+
+  val Analysis = sbt.inc.Analysis
+
+  def addWatchSources(
+    unmanagedSourcesKey: TaskKey[Seq[File]],
+    unmanagedSourceDirectoriesKey: SettingKey[Seq[File]],
+    scopeKey: Configuration
+  ) = {
+    Keys.watchSources ++= (unmanagedSourcesKey in scopeKey).value
+  }
+
+  type CacheStore = File
+  def cacheStore(stream: Keys.TaskStreams, identifier: String): CacheStore = stream.cacheDirectory / identifier
+
+  def terminateActorSystem(actorSystem: ActorSystem) = actorSystem.shutdown()
+}

--- a/src/main/scala-sbt-0.13/com/typesafe/sbt/web/CompilationExceptions.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbt/web/CompilationExceptions.scala
@@ -1,0 +1,111 @@
+package com.typesafe.sbt.web
+
+import sbt._
+import xsbti._
+
+object CompileProblems {
+
+  type LoggerReporter = sbt.LoggerReporter
+
+  /**
+   * Report compilation problems using the given reporter.
+   * 
+   * If there are any compilation problems with Error severity, then a
+   * `CompileProblemsException` is thrown. The exception will contain
+   * the list of problems.
+   */
+  def report[Op,A](reporter: Reporter, problems: Seq[Problem]): Unit = {
+    reporter.reset()
+    problems.foreach(p => reporter.log(p.position(), p.message(), p.severity()))
+    reporter.printSummary()
+    if (problems.exists(_.severity() == Severity.Error)) { throw new CompileProblemsException(problems.toArray) }
+  }
+
+}
+
+/**
+ * Exception thrown by `CompileProblems.report` if there are any problems
+ * to report. This exception contains the problems so they can be used
+ * for further processing (e.g. for display by Play).
+ */
+class CompileProblemsException(override val problems: Array[Problem])
+  extends CompileFailed
+  with FeedbackProvidedException {
+
+  override val arguments: Array[String] = Array.empty
+}
+
+/**
+ * Capture a general problem with the compilation of a source file. General problems
+ * have no associated line number and are always regarded as errors.
+ * @param message The message to report.
+ * @param source The source file containing the general error.
+ */
+class GeneralProblem(val message: String, source: File) extends Problem {
+  def category(): String = ""
+
+  def severity(): Severity = Severity.Error
+
+  def position(): Position = new Position {
+    def line(): Maybe[Integer] = Maybe.nothing()
+
+    def lineContent(): String = ""
+
+    def offset(): Maybe[Integer] = Maybe.nothing()
+
+    def pointer(): Maybe[Integer] = Maybe.nothing()
+
+    def pointerSpace(): Maybe[String] = Maybe.nothing()
+
+    def sourcePath(): Maybe[String] = Maybe.just(source.getCanonicalPath)
+
+    def sourceFile(): Maybe[File] = Maybe.just(source)
+  }
+}
+
+/**
+ * Capture a line/column position along with the line's content for a given source file.
+ * @param lineNumber The line number - starts at 1.
+ * @param lineContent The content of the line itself.
+ * @param characterOffset The offset character position - starts at 0.
+ * @param source The associated source file.
+ */
+class LinePosition(
+                    lineNumber: Int,
+                    override val lineContent: String,
+                    characterOffset: Int,
+                    source: File
+                    ) extends Position {
+  def line(): Maybe[Integer] = Maybe.just(lineNumber)
+
+  def offset(): Maybe[Integer] = Maybe.just(characterOffset)
+
+  def pointer(): Maybe[Integer] = offset()
+
+  def pointerSpace(): Maybe[String] = Maybe.just(
+    lineContent.take(pointer().get).map {
+      case '\t' => '\t'
+      case x => ' '
+    })
+
+  def sourcePath(): Maybe[String] = Maybe.just(source.getPath)
+
+  def sourceFile(): Maybe[File] = Maybe.just(source)
+}
+
+/**
+ * Capture a problem associated with a line number and character offset.
+ */
+class LineBasedProblem(
+                        override val message: String,
+                        override val severity: Severity,
+                        lineNumber: Int,
+                        characterOffset: Int,
+                        lineContent: String,
+                        source: File
+                        ) extends Problem {
+
+  def category(): String = ""
+
+  override def position: Position = new LinePosition(lineNumber, lineContent, characterOffset, source)
+}

--- a/src/main/scala-sbt-0.13/com/typesafe/sbt/web/incremental/OpCacheIO.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbt/web/incremental/OpCacheIO.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package com.typesafe.sbt.web.incremental
+
+import java.io.File
+
+import sbinary.Operations._
+import sbinary._
+import sbt.CacheIO
+
+import scala.collection.immutable.{Map, Set}
+
+/**
+ * Support for reading and writing cache files.
+ */
+private[incremental] object OpCacheIO {
+
+  import OpCacheProtocol.OpCacheFormatV2
+
+  def toFile(cache: OpCache, file: File): Unit = {
+    CacheIO.toFile(OpCacheFormatV2)(cache)(file)
+  }
+
+  def fromFile(file: File): OpCache = {
+    CacheIO.fromFile(OpCacheFormatV2, new OpCache())(file)
+  }
+
+}
+
+/**
+ * Binary formats for cache files.
+ */
+private[incremental] object OpCacheProtocol extends DefaultProtocol {
+
+  import OpCache.{FileHash, Record}
+
+  implicit def cacheContentFormat: Format[Map[OpInputHash, Record]] =
+    immutableMapFormat[OpInputHash, Record](OpInputHashFormat, RecordFormat)
+
+  implicit def fileDepsFormat: Format[Set[FileHash]] =
+    immutableSetFormat[FileHash](FileHashFormat)
+
+  /**
+   * SBT's CacheIO stores a hash of the format type in the cache. By including a version number in the name, and
+   * incrementing that version number each time the format changes, this ensures that when the version changes,
+   * SBT won't try and load the cache, but will treat it as if there is no cache.
+   */
+  implicit object OpCacheFormatV2 extends Format[OpCache] {
+    def reads(in: Input): OpCache = new OpCache(read[Map[OpInputHash, Record]](in))
+    def writes(out: Output, oc: OpCache) = write[Map[OpInputHash, Record]](out, oc.content)
+  }
+
+  implicit object BytesFormat extends Format[Bytes] {
+    def reads(in: Input): Bytes = Bytes(read[Array[Byte]](in))
+    def writes(out: Output, bytes: Bytes) = write[Array[Byte]](out, bytes.arr)
+  }
+
+  implicit object OpInputHashFormat extends Format[OpInputHash] {
+    def reads(in: Input): OpInputHash = OpInputHash(read[Bytes](in))
+    def writes(out: Output, oih: OpInputHash) = write[Bytes](out, oih.bytes)
+  }
+
+  implicit object RecordFormat extends Format[Record] {
+    def reads(in: Input): Record = Record(read[Set[FileHash]](in), read[Set[File]](in))
+    def writes(out: Output, r: Record) = {
+      write[Set[FileHash]](out, r.fileHashes)
+      write[Set[File]](out, r.products)
+    }
+  }
+
+  implicit object FileHashFormat extends Format[FileHash] {
+    def reads(in: Input): FileHash = FileHash(read[File](in), read[Option[Bytes]](in))
+    def writes(out: Output, fh: FileHash) = {
+      write[File](out, fh.file)
+      write[Option[Bytes]](out, fh.sha1IfExists)
+    }
+  }
+
+}

--- a/src/main/scala-sbt-1.0/com/typesafe/sbt/web/Compat.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbt/web/Compat.scala
@@ -1,0 +1,30 @@
+package com.typesafe.sbt.web
+
+import sbt.{Configuration, File, Keys, SettingKey, TaskKey}
+import sbt.internal.io.Source
+import akka.actor.ActorSystem
+
+object Compat {
+
+  val Analysis = sbt.internal.inc.Analysis
+
+  def addWatchSources(
+    unmanagedSourcesKey: TaskKey[Seq[File]],
+    unmanagedSourceDirectoriesKey: SettingKey[Seq[File]],
+    scopeKey: Configuration
+  ) = {
+    Keys.watchSources ++= {
+      val include = (Keys.includeFilter in unmanagedSourcesKey in scopeKey).value
+      val exclude = (Keys.excludeFilter in unmanagedSourcesKey in scopeKey).value
+
+      (unmanagedSourceDirectoriesKey in scopeKey).value.map { directory =>
+        new Source(directory, include, exclude)
+      }
+    }
+  }
+
+  type CacheStore = sbt.util.CacheStore
+  def cacheStore(stream: Keys.TaskStreams, identifier: String): CacheStore = stream.cacheStoreFactory.make(identifier)
+
+  def terminateActorSystem(actorSystem: ActorSystem) = actorSystem.terminate()
+}

--- a/src/main/scala-sbt-1.0/com/typesafe/sbt/web/incremental/OpCacheIO.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbt/web/incremental/OpCacheIO.scala
@@ -4,13 +4,17 @@
 package com.typesafe.sbt.web.incremental
 
 import java.io.File
-import sbinary._
+
 import sbinary.Operations._
+import sbinary._
 import sbt.CacheIO
-import scala.collection.immutable.{ Map, Set }
+
+import scala.collection.immutable.{Map, Set}
 
 /**
  * Support for reading and writing cache files.
+ *
+ * TODO: CONVERT TO NEW SBT CACHE API
  */
 private[incremental] object OpCacheIO {
 
@@ -31,7 +35,7 @@ private[incremental] object OpCacheIO {
  */
 private[incremental] object OpCacheProtocol extends DefaultProtocol {
 
-  import OpCache.{ FileHash, Record }
+  import OpCache.{FileHash, Record}
 
   implicit def cacheContentFormat: Format[Map[OpInputHash, Record]] =
     immutableMapFormat[OpInputHash, Record](OpInputHashFormat, RecordFormat)

--- a/src/main/scala/com/typesafe/sbt/web/incremental/OpInputHash.scala
+++ b/src/main/scala/com/typesafe/sbt/web/incremental/OpInputHash.scala
@@ -9,7 +9,7 @@ import sbt.Hash
  * A hash of an operation's input. Used to check if two operations have the
  * same or different inputs.
  */
-case class OpInputHash(val bytes: Bytes)
+case class OpInputHash(bytes: Bytes)
 
 /**
  * Factory methods for OpInputHash.

--- a/src/sbt-test/sbt-web/asset-pipeline/build.sbt
+++ b/src/sbt-test/sbt-web/asset-pipeline/build.sbt
@@ -11,7 +11,7 @@ coffee := {
   val sourceDir = (sourceDirectory in Assets).value
   val targetDir = target.value / "cs-plugin"
   val sources = sourceDir ** "*.coffee"
-  val mappings = sources pair relativeTo(sourceDir)
+  val mappings = sources pair Path.relativeTo(sourceDir)
   val renamed = mappings map { case (file, path) => file -> path.replaceAll("coffee", "js") }
   val copies = renamed map { case (file, path) => file -> (resourceManaged in Assets).value / path }
   IO.copy(copies)
@@ -22,14 +22,17 @@ sourceGenerators in Assets += coffee.taskValue
 
 val jsmin = taskKey[Pipeline.Stage]("mock js minifier")
 
-jsmin := { (mappings: Seq[PathMapping]) =>
-  // pretend to combine all .js files into one .min.js file
+jsmin := {
   val targetDir = target.value / "jsmin" / "public"
-  val (js, other) = mappings partition (_._2.endsWith(".js"))
-  val minFile = targetDir / "js" / "all.min.js"
-  IO.touch(minFile)
-  val minMappings = Seq(minFile) pair relativeTo(targetDir)
-  minMappings ++ other
+
+  { (mappings: Seq[PathMapping]) =>
+    // pretend to combine all .js files into one .min.js file
+    val (js, other) = mappings partition (_._2.endsWith(".js"))
+    val minFile = targetDir / "js" / "all.min.js"
+    IO.touch(minFile)
+    val minMappings = Seq(minFile) pair Path.relativeTo(targetDir)
+    minMappings ++ other
+  }
 }
 
 pipelineStages := Seq(jsmin)

--- a/src/sbt-test/sbt-web/asset-pipeline/project/build.properties
+++ b/src/sbt-test/sbt-web/asset-pipeline/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/sbt-web/asset-pipeline/test
+++ b/src/sbt-test/sbt-web/asset-pipeline/test
@@ -1,3 +1,3 @@
-> web-stage
+> webStage
 $ exists target/web/stage/js/all.min.js
 $ exists target/web/stage/coffee/a.coffee

--- a/src/sbt-test/sbt-web/deduplicate/project/build.properties
+++ b/src/sbt-test/sbt-web/deduplicate/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/sbt-web/dev-pipeline/build.sbt
+++ b/src/sbt-test/sbt-web/dev-pipeline/build.sbt
@@ -6,18 +6,21 @@ lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
 val transform = taskKey[Pipeline.Stage]("js transformer")
 
-transform := { (mappings: Seq[PathMapping]) =>
-  // transform js files - rename as .new.js just for testing
+transform := {
   val targetDir = target.value / "transform"
-  val (jsMappings, otherMappings) = mappings partition (_._2.endsWith(".js"))
-  val transformedMappings = jsMappings map {
-    case (file, path) =>
-      val newPath = path.dropRight(3) + ".new.js"
-      val newFile = targetDir / newPath
-      IO.touch(newFile)
-      newFile -> newPath
+
+  { (mappings: Seq[PathMapping]) =>
+    // transform js files - rename as .new.js just for testing
+    val (jsMappings, otherMappings) = mappings partition (_._2.endsWith(".js"))
+    val transformedMappings = jsMappings map {
+      case (file, path) =>
+        val newPath = path.dropRight(3) + ".new.js"
+        val newFile = targetDir / newPath
+        IO.touch(newFile)
+        newFile -> newPath
+    }
+    transformedMappings ++ otherMappings
   }
-  transformedMappings ++ otherMappings
 }
 
 pipelineStages in Assets := Seq(transform)

--- a/src/sbt-test/sbt-web/dev-pipeline/project/build.properties
+++ b/src/sbt-test/sbt-web/dev-pipeline/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/sbt-web/exclude-hidden-files/project/build.properties
+++ b/src/sbt-test/sbt-web/exclude-hidden-files/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/sbt-web/extract-web-jars/project/build.properties
+++ b/src/sbt-test/sbt-web/extract-web-jars/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/sbt-web/extract-web-jars/test
+++ b/src/sbt-test/sbt-web/extract-web-jars/test
@@ -5,7 +5,7 @@ $ exists target/web/public/main/lib/prototype/prototype.js
 -$ exists target/web/public/main/lib/requirejs/require.js
 
 # Extract node modules
-> web-assets:web-node-modules
+> web-assets:webNodeModules
 $ exists target/web/node-modules/main/webjars/less/package.json
 
 > clean

--- a/src/sbt-test/sbt-web/multi-module/project/build.properties
+++ b/src/sbt-test/sbt-web/multi-module/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/sbt-web/package/project/build.properties
+++ b/src/sbt-test/sbt-web/package/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/sbt-web/publish-webjar/project/build.properties
+++ b/src/sbt-test/sbt-web/publish-webjar/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11


### PR DESCRIPTION
Most things compile, except for `OpCacheIO` needs to be migrated to the new json based sbt cache API. Moving to that API is fairly involved, it requires rewriting all the sbinary formats to sjson-new formats, which I don't have time for right now.

Cross building with sbt 0.13 has been maintained, using `scala-sbt-*` folders for non source compatible changes.