### PR TITLE
Error reporting should be using the ManagedLoggedReporter

### DIFF
--- a/src/main/scala-sbt-0.13/com/typesafe/sbt/web/CompilationExceptions.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbt/web/CompilationExceptions.scala
@@ -91,6 +91,8 @@ class LinePosition(
   def sourcePath(): Maybe[String] = Maybe.just(source.getPath)
 
   def sourceFile(): Maybe[File] = Maybe.just(source)
+
+  override def toString = s"$source:$lineNumber:$characterOffset"
 }
 
 /**

--- a/src/main/scala-sbt-1.0/com/typesafe/sbt/web/CompilationExceptions.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbt/web/CompilationExceptions.scala
@@ -6,7 +6,7 @@ import java.util.Optional
 
 object CompileProblems {
 
-  type LoggerReporter = sbt.internal.inc.LoggedReporter
+  type LoggerReporter = sbt.internal.inc.ManagedLoggedReporter
 
   /**
    * Report compilation problems using the given reporter.
@@ -92,6 +92,8 @@ class LinePosition(
   def sourcePath(): Optional[String] = Optional.of(source.getPath)
 
   def sourceFile(): Optional[File] = Optional.of(source)
+
+  override def toString = s"$source:$lineNumber:$characterOffset"
 }
 
 /**


### PR DESCRIPTION
This ensures nice error messages with source code context.