### PR TITLE
Delete stale webjars files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ libraryDependencies ++= Seq(
     case "2.10" => "2.3.16"
     case _ => "2.5.4"
   }),
-  "org.webjars" % "webjars-locator-core" % "0.32",
+  "org.webjars" % "webjars-locator-core" % "0.33",
   "org.specs2" %% "specs2-core" % "3.8.9" % "test",
   "junit" % "junit" % "4.12" % "test"
 )

--- a/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
@@ -423,6 +423,9 @@ object SbtWeb extends AutoPlugin {
     val cache = new FileSystemCache(cacheFile)
     val extractor = new WebJarExtractor(cache, classLoader)
     block(extractor, to)
+    import scala.collection.JavaConverters._
+    // Delete any files that were in the cache but weren't found by the extractor
+    cache.getExistingUntouchedFiles(to).asScala.foreach(_.delete())
     cache.save()
     to
   }


### PR DESCRIPTION
This is to fix issues like https://github.com/sbt/sbt-less/issues/80, where when a webjar is upgraded, and a clean isn't done (especially for the webjars associated with sbt plugins because they are extracted to the project/target directory which doesn't get cleaned by clean), the old files left hanging around from the old version that have been deleted from the new version of the webjar can cause a problem.

See https://github.com/webjars/webjars-locator-core/pull/18 for details of change made to webjars-locator-core to facilitate this fix.