### PR TITLE
Add my sbt-puresass plugin to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following is a list of plugins we know of that are built on sbt-web:
 * [sbt-rjs](https://github.com/sbt/sbt-rjs#sbt-rjs)
 * [sbt-sass](https://github.com/madoushi/sbt-sass)
 * [sbt-sassify](https://github.com/irundaia/sbt-sassify)
+* [sbt-puresass](https://chiselapp.com/user/twenstar/repository/sbt-puresass)
 * [sbt-simple-url-update](https://github.com/neomaclin/sbt-simple-url-update#sbt-simple-url-update)
 * [sbt-stylus](https://github.com/sbt/sbt-stylus)
 * [sbt-traceur](https://github.com/LuigiPeace/sbt-traceur)


### PR DESCRIPTION
sbt-puresass provides Sass compiling in pure JVM, no external binary necessary.

Release notes: https://chiselapp.com/user/twenstar/repository/sbt-puresass/technote/a200f9630650f40d2a448ae290a25d7a8f119fbf