### PR TITLE
Add sbt-vuefy to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following is a list of plugins we know of that are built on sbt-web:
 * [sbt-tslint](https://github.com/joost-de-vries/sbt-tslint)
 * [sbt-typescript](https://github.com/joost-de-vries/sbt-typescript)
 * [sbt-uglify](https://github.com/sbt/sbt-uglify)
+* [sbt-vuefy](https://github.com/GIVESocialMovement/sbt-vuefy)
 * [sbt-web-scalajs](https://github.com/vmunier/sbt-web-scalajs)
 
 Ideas for Plugins


### PR DESCRIPTION
sbt-vuefy integrates Vue.js with Playframework n a traditional way (not SPA) . The plugin hot-reloads `*.vue` to `*.js` during`sbt run` using sbt-web’s syncIncremental. It also tracks dependencies and etc.

A complete example is here: https://github.com/GIVESocialMovement/sbt-vuefy/tree/master/test-play-project

I hope it will be useful for people who want to use Vue.js with Play. Please let me know if this is ok. Thank you.