### PR TITLE
Add configurations to projectConfigurations

### DIFF
--- a/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
@@ -142,6 +142,8 @@ object SbtWeb extends AutoPlugin {
   import autoImport._
   import WebKeys._
 
+  override def projectConfigurations = super.projectConfigurations ++ Seq(Assets, TestAssets, Plugin)
+
   override def globalSettings: Seq[Setting[_]] = super.globalSettings ++ Seq(
     onLoad in Global := (onLoad in Global).value andThen load,
     onUnload in Global := (onUnload in Global).value andThen unload


### PR DESCRIPTION
This avoids warnings in sbt 1.2.0 such as

```text
[warn] The project ProjectRef(uri("file:/XXX"), "app_common") references an unknown configuration "web-plugin" and was guessed to be "Web-plugin".
[warn] This configuration should be explicitly added to the project.
[warn] The project ProjectRef(uri("file:/XXX"), "app_common") references an unknown configuration "web-assets" and was guessed to be "Web-assets".
````