### PR TITLE
Scripted sbt2 compatibility

### DIFF
--- a/src/main/scala-2.12/com/typesafe/sbt/PluginCompat.scala
+++ b/src/main/scala-2.12/com/typesafe/sbt/PluginCompat.scala
@@ -8,7 +8,7 @@ import java.nio.file.{ Path => NioPath }
 
 private[sbt] object PluginCompat {
   type FileRef = java.io.File
-  type Out = java.io.File
+  type UnhashedFileRef = java.io.File
 
   def toNioPath(a: Attributed[File])(implicit conv: FileConverter): NioPath =
     a.data.toPath

--- a/src/main/scala-3/com/typesafe/sbt/PluginCompat.scala
+++ b/src/main/scala-3/com/typesafe/sbt/PluginCompat.scala
@@ -4,11 +4,11 @@ import java.nio.file.{ Path => NioPath }
 import java.io.{ File => IoFile }
 import sbt.*
 import sbt.Keys.Classpath
-import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFile }
+import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFileRef }
 
 private[sbt] object PluginCompat:
   type FileRef = HashedVirtualFileRef
-  type Out = VirtualFile
+  type UnhashedFileRef = VirtualFileRef
 
   def toNioPath(a: Attributed[HashedVirtualFileRef])(using conv: FileConverter): NioPath =
     conv.toPath(a.data)
@@ -22,9 +22,9 @@ private[sbt] object PluginCompat:
   inline def classpathToFiles(classpath: Classpath)(using conv: FileConverter): Seq[File] =
     toFiles(classpath.to(Seq))
   inline def toKey(settingKey: SettingKey[String]): StringAttributeKey = StringAttributeKey(settingKey.key.label)
-  def toNioPath(hvf: HashedVirtualFileRef)(using conv: FileConverter): NioPath =
+  def toNioPath(hvf: VirtualFileRef)(using conv: FileConverter): NioPath =
     conv.toPath(hvf)
-  def toFile(hvf: HashedVirtualFileRef)(using conv: FileConverter): File =
+  def toFile(hvf: VirtualFileRef)(using conv: FileConverter): File =
     toNioPath(hvf).toFile
   inline def toFileRef(file: File)(using conv: FileConverter): FileRef =
     conv.toVirtualFile(file.toPath)

--- a/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
@@ -586,6 +586,20 @@ object SbtWeb extends AutoPlugin {
   }
 
   /**
+   * Convert a FileRef to a File, for compatibility usage in user sbt files/tasks
+   * @param fileRef
+   *   The file ref to convert
+   * @param conv
+   *   A valid FileConverter. Usually fileConverter.value, in Task scope
+   * @return
+   *   The file converted to a usable File type.
+   */
+  def asFile(fileRef: UnhashedFileRef, conv: FileConverter): File = {
+    implicit val fc: FileConverter = conv
+    toFile(fileRef)
+  }
+
+  /**
    * Deduplicator that selects the first file contained in the base directory.
    *
    * @param base

--- a/src/sbt-test/sbt-web/asset-pipeline/build.sbt
+++ b/src/sbt-test/sbt-web/asset-pipeline/build.sbt
@@ -31,8 +31,16 @@ jsmin := {
     val minFile = targetDir / "js" / "all.min.js"
     IO.touch(minFile)
     val minMappings = Seq(minFile) pair Path.relativeTo(targetDir)
-    minMappings ++ other
+    val convertedMinMappings = minMappings.map{ case (file, path) =>
+      SbtWeb.asFileRef(file, fileConverter.value) -> path
+    }
+    convertedMinMappings ++ other
   }
 }
 
 pipelineStages := Seq(jsmin)
+
+TaskKey[Unit]("fileCheck") := {
+  assert((target.value / "jsmin" / "public" / "js" / "all.min.js").exists())
+  assert((target.value / "web" / "stage" / "coffee" / "a.coffee").exists())
+}

--- a/src/sbt-test/sbt-web/asset-pipeline/build.sbt
+++ b/src/sbt-test/sbt-web/asset-pipeline/build.sbt
@@ -31,7 +31,7 @@ jsmin := {
     val minFile = targetDir / "js" / "all.min.js"
     IO.touch(minFile)
     val minMappings = Seq(minFile) pair Path.relativeTo(targetDir)
-    val convertedMinMappings = minMappings.map{ case (file, path) =>
+    val convertedMinMappings = minMappings.map { case (file, path) =>
       SbtWeb.asFileRef(file, fileConverter.value) -> path
     }
     convertedMinMappings ++ other

--- a/src/sbt-test/sbt-web/asset-pipeline/build.sbt
+++ b/src/sbt-test/sbt-web/asset-pipeline/build.sbt
@@ -40,7 +40,9 @@ jsmin := {
 
 pipelineStages := Seq(jsmin)
 
+// $ exists target/web/stage/js/all.min.js
+// $ exists target/web/stage/coffee/a.coffee
 TaskKey[Unit]("fileCheck") := {
-  assert((target.value / "jsmin" / "public" / "js" / "all.min.js").exists())
+  assert((target.value / "web" / "stage" / "js" / "all.min.js").exists())
   assert((target.value / "web" / "stage" / "coffee" / "a.coffee").exists())
 }

--- a/src/sbt-test/sbt-web/asset-pipeline/test
+++ b/src/sbt-test/sbt-web/asset-pipeline/test
@@ -1,3 +1,2 @@
 > webStage
-$ exists target/web/stage/js/all.min.js
-$ exists target/web/stage/coffee/a.coffee
+> fileCheck

--- a/src/sbt-test/sbt-web/deduplicate/build.sbt
+++ b/src/sbt-test/sbt-web/deduplicate/build.sbt
@@ -1,3 +1,7 @@
 lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
 Assets / WebKeys.deduplicators += SbtWeb.selectFileFrom((Assets / sourceDirectory).value)
+
+TaskKey[Unit]("fileCheck") := {
+  assert(( target.value / "web" / "public" / "main" / "js" / "a.js" ).exists(), "Could not find 'web/public/main/js/a.js'")
+}

--- a/src/sbt-test/sbt-web/deduplicate/build.sbt
+++ b/src/sbt-test/sbt-web/deduplicate/build.sbt
@@ -3,5 +3,8 @@ lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 Assets / WebKeys.deduplicators += SbtWeb.selectFileFrom((Assets / sourceDirectory).value)
 
 TaskKey[Unit]("fileCheck") := {
-  assert(( target.value / "web" / "public" / "main" / "js" / "a.js" ).exists(), "Could not find 'web/public/main/js/a.js'")
+  assert(
+    (target.value / "web" / "public" / "main" / "js" / "a.js").exists(),
+    "Could not find 'web/public/main/js/a.js'"
+  )
 }

--- a/src/sbt-test/sbt-web/deduplicate/test
+++ b/src/sbt-test/sbt-web/deduplicate/test
@@ -1,2 +1,2 @@
 > assets
-$ exists target/web/public/main/js/a.js
+> fileCheck

--- a/src/sbt-test/sbt-web/dev-pipeline/build.sbt
+++ b/src/sbt-test/sbt-web/dev-pipeline/build.sbt
@@ -16,10 +16,15 @@ jsTransform := {
       val newPath = path.dropRight(3) + ".new.js"
       val newFile = targetDir / newPath
       IO.touch(newFile)
-      newFile -> newPath
+      SbtWeb.asFileRef(newFile, fileConverter.value) -> newPath
     }
     transformedMappings ++ otherMappings
   }
 }
 
 Assets / pipelineStages := Seq(jsTransform)
+
+TaskKey[Unit]("fileCheck") := {
+  assert(!( target.value / "web" / "public" / "main" / "js" / "a.js" ).exists(), "Found 'web/public/main/js/a.js', which should not exist.")
+  assert(( target.value / "web" / "public" / "main" / "js" / "a.new.js" ).exists(), "Could not find 'web/public/main/js/a.new.js'")
+}

--- a/src/sbt-test/sbt-web/dev-pipeline/build.sbt
+++ b/src/sbt-test/sbt-web/dev-pipeline/build.sbt
@@ -25,6 +25,12 @@ jsTransform := {
 Assets / pipelineStages := Seq(jsTransform)
 
 TaskKey[Unit]("fileCheck") := {
-  assert(!( target.value / "web" / "public" / "main" / "js" / "a.js" ).exists(), "Found 'web/public/main/js/a.js', which should not exist.")
-  assert(( target.value / "web" / "public" / "main" / "js" / "a.new.js" ).exists(), "Could not find 'web/public/main/js/a.new.js'")
+  assert(
+    !(target.value / "web" / "public" / "main" / "js" / "a.js").exists(),
+    "Found 'web/public/main/js/a.js', which should not exist."
+  )
+  assert(
+    (target.value / "web" / "public" / "main" / "js" / "a.new.js").exists(),
+    "Could not find 'web/public/main/js/a.new.js'"
+  )
 }

--- a/src/sbt-test/sbt-web/dev-pipeline/test
+++ b/src/sbt-test/sbt-web/dev-pipeline/test
@@ -1,3 +1,2 @@
 > assets
-$ absent target/web/public/main/js/a.js
-$ exists target/web/public/main/js/a.new.js
+> fileCheck

--- a/src/sbt-test/sbt-web/exclude-hidden-files/build.sbt
+++ b/src/sbt-test/sbt-web/exclude-hidden-files/build.sbt
@@ -1,1 +1,5 @@
 lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+
+TaskKey[Unit]("fileCheck") := {
+  assert(!( target.value / "web" / "public" / "main" / ".svn" / "entries" ).exists(), "Found private directory, which should have been excluded.")
+}

--- a/src/sbt-test/sbt-web/exclude-hidden-files/build.sbt
+++ b/src/sbt-test/sbt-web/exclude-hidden-files/build.sbt
@@ -1,5 +1,8 @@
 lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
 TaskKey[Unit]("fileCheck") := {
-  assert(!( target.value / "web" / "public" / "main" / ".svn" / "entries" ).exists(), "Found private directory, which should have been excluded.")
+  assert(
+    !(target.value / "web" / "public" / "main" / ".svn" / "entries").exists(),
+    "Found private directory, which should have been excluded."
+  )
 }

--- a/src/sbt-test/sbt-web/exclude-hidden-files/test
+++ b/src/sbt-test/sbt-web/exclude-hidden-files/test
@@ -1,2 +1,2 @@
 > assets
-$ absent target/web/public/main/.svn/entries
+> fileCheck

--- a/src/sbt-test/sbt-web/extract-web-jars/build.sbt
+++ b/src/sbt-test/sbt-web/extract-web-jars/build.sbt
@@ -6,3 +6,77 @@ libraryDependencies ++= Seq(
   "org.webjars" % "less-node" % "1.6.0-1",
   "org.webjars" % "requirejs" % "2.1.11-1" % "test"
 )
+
+//$ exists target/web/public/main/lib/jquery/jquery.js
+//$ exists target/web/public/main/lib/prototype/prototype.js
+//-$ exists target/web/public/main/lib/requirejs/require.js
+TaskKey[Unit]("fileCheckAssets") := {
+  assert(
+    ( target.value / "web" / "public" / "main" / "lib" / "jquery" / "jquery.js" ).exists(),
+    "Could not find jquery.js"
+  )
+  assert(
+    ( target.value / "web" / "public" / "main" / "lib" / "prototype" / "prototype.js" ).exists(),
+    "Could not find prototype.js"
+  )
+  assert(
+    !( target.value / "web" / "public" / "main" / "lib" / "requirejs" / "require.js" ).exists(),
+    "Found requirejs, which should have been excluded."
+  )
+
+}
+
+//$ exists target/web/node-modules/main/webjars/less/package.json
+TaskKey[Unit]("fileCheckNode") := {
+  assert(
+    ( target.value / "web" / "node-modules" / "main" / "webjars" / "less" / "package.json" ).exists(),
+    "Could not find node webjars"
+  )
+}
+
+//# jquery.js should not have been re-extracted, assert that it is older
+//$ newer target/foo target/web/public/main/lib/jquery/jquery.js
+TaskKey[Unit]("checkJqueryTimestamp") := {
+  assert(
+    ( target.value / "web" / "public" / "main" / "lib" / "jquery" / "jquery.js" ).exists(),
+    "Could not find jquery"
+  )
+}
+
+//# All webjars on test classpath are extracted for tests
+//$ exists target/web/web-modules/test/webjars/lib/requirejs/require.js
+//$ exists target/web/web-modules/test/webjars/lib/jquery/jquery.js
+//$ exists target/web/web-modules/test/webjars/lib/prototype/prototype.js
+TaskKey[Unit]("checkTestAssets") := {
+  assert(
+    ( target.value / "web" / "web-modules" / "test" / "webjars" / "lib" / "requirejs" / "require.js" ).exists(),
+    "Could not find requirejs webjars in test"
+  )
+  assert(
+    ( target.value / "web" / "web-modules" / "test" / "webjars" / "lib" / "jquery" / "jquery.js" ).exists(),
+    "Could not find jquery webjars in test"
+  )
+  assert(
+    ( target.value / "web" / "web-modules" / "test" / "webjars" / "lib" / "prototype" / "prototype.js" ).exists(),
+    "Could not find prototype webjars in test"
+  )
+}
+
+//# Now check everything was aggregated in test assets
+//$ exists target/web/public/test/lib/jquery/jquery.js
+//$ exists target/web/public/test/lib/prototype/prototype.js
+//$ exists target/web/public/test/lib/requirejs/require.js
+TaskKey[Unit]("checkTestLibs") := {
+  assert(
+    ( target.value / "web" / "public" / "test" / "lib" / "requirejs" / "require.js" ).exists(),
+    "Could not find requirejs library in test"
+  )
+  assert(
+    ( target.value / "web" / "public" / "test" / "lib" / "jquery" / "jquery.js" ).exists(),
+    "Could not find jquery library in test"
+  )
+  assert(
+    ( target.value / "web" / "public" / "test" / "lib" / "prototype" / "prototype.js" ).exists(),
+    "Could not find prototype library in test"
+  )
+}

--- a/src/sbt-test/sbt-web/extract-web-jars/build.sbt
+++ b/src/sbt-test/sbt-web/extract-web-jars/build.sbt
@@ -38,8 +38,8 @@ TaskKey[Unit]("fileCheckNode") := {
 //$ newer target/foo target/web/public/main/lib/jquery/jquery.js
 TaskKey[Unit]("checkJqueryTimestamp") := {
   assert(
-    ( target.value / "web" / "public" / "main" / "lib" / "jquery" / "jquery.js" ).exists(),
-    "Could not find jquery"
+    (baseDirectory.value / "target" / "foo" ).lastModified() > (target.value / "web" / "public" / "main" / "lib" / "jquery" / "jquery.js" ).lastModified(),
+    "target/foo was not newer than jquery.js"
   )
 }
 

--- a/src/sbt-test/sbt-web/extract-web-jars/build.sbt
+++ b/src/sbt-test/sbt-web/extract-web-jars/build.sbt
@@ -12,15 +12,15 @@ libraryDependencies ++= Seq(
 //-$ exists target/web/public/main/lib/requirejs/require.js
 TaskKey[Unit]("fileCheckAssets") := {
   assert(
-    ( target.value / "web" / "public" / "main" / "lib" / "jquery" / "jquery.js" ).exists(),
+    (target.value / "web" / "public" / "main" / "lib" / "jquery" / "jquery.js").exists(),
     "Could not find jquery.js"
   )
   assert(
-    ( target.value / "web" / "public" / "main" / "lib" / "prototype" / "prototype.js" ).exists(),
+    (target.value / "web" / "public" / "main" / "lib" / "prototype" / "prototype.js").exists(),
     "Could not find prototype.js"
   )
   assert(
-    !( target.value / "web" / "public" / "main" / "lib" / "requirejs" / "require.js" ).exists(),
+    !(target.value / "web" / "public" / "main" / "lib" / "requirejs" / "require.js").exists(),
     "Found requirejs, which should have been excluded."
   )
 
@@ -29,7 +29,7 @@ TaskKey[Unit]("fileCheckAssets") := {
 //$ exists target/web/node-modules/main/webjars/less/package.json
 TaskKey[Unit]("fileCheckNode") := {
   assert(
-    ( target.value / "web" / "node-modules" / "main" / "webjars" / "less" / "package.json" ).exists(),
+    (target.value / "web" / "node-modules" / "main" / "webjars" / "less" / "package.json").exists(),
     "Could not find node webjars"
   )
 }
@@ -38,7 +38,8 @@ TaskKey[Unit]("fileCheckNode") := {
 //$ newer target/foo target/web/public/main/lib/jquery/jquery.js
 TaskKey[Unit]("checkJqueryTimestamp") := {
   assert(
-    (baseDirectory.value / "target" / "foo" ).lastModified() > (target.value / "web" / "public" / "main" / "lib" / "jquery" / "jquery.js" ).lastModified(),
+    (baseDirectory.value / "target" / "foo")
+      .lastModified() > (target.value / "web" / "public" / "main" / "lib" / "jquery" / "jquery.js").lastModified(),
     "target/foo was not newer than jquery.js"
   )
 }
@@ -49,15 +50,15 @@ TaskKey[Unit]("checkJqueryTimestamp") := {
 //$ exists target/web/web-modules/test/webjars/lib/prototype/prototype.js
 TaskKey[Unit]("checkTestAssets") := {
   assert(
-    ( target.value / "web" / "web-modules" / "test" / "webjars" / "lib" / "requirejs" / "require.js" ).exists(),
+    (target.value / "web" / "web-modules" / "test" / "webjars" / "lib" / "requirejs" / "require.js").exists(),
     "Could not find requirejs webjars in test"
   )
   assert(
-    ( target.value / "web" / "web-modules" / "test" / "webjars" / "lib" / "jquery" / "jquery.js" ).exists(),
+    (target.value / "web" / "web-modules" / "test" / "webjars" / "lib" / "jquery" / "jquery.js").exists(),
     "Could not find jquery webjars in test"
   )
   assert(
-    ( target.value / "web" / "web-modules" / "test" / "webjars" / "lib" / "prototype" / "prototype.js" ).exists(),
+    (target.value / "web" / "web-modules" / "test" / "webjars" / "lib" / "prototype" / "prototype.js").exists(),
     "Could not find prototype webjars in test"
   )
 }
@@ -68,15 +69,15 @@ TaskKey[Unit]("checkTestAssets") := {
 //$ exists target/web/public/test/lib/requirejs/require.js
 TaskKey[Unit]("checkTestLibs") := {
   assert(
-    ( target.value / "web" / "public" / "test" / "lib" / "requirejs" / "require.js" ).exists(),
+    (target.value / "web" / "public" / "test" / "lib" / "requirejs" / "require.js").exists(),
     "Could not find requirejs library in test"
   )
   assert(
-    ( target.value / "web" / "public" / "test" / "lib" / "jquery" / "jquery.js" ).exists(),
+    (target.value / "web" / "public" / "test" / "lib" / "jquery" / "jquery.js").exists(),
     "Could not find jquery library in test"
   )
   assert(
-    ( target.value / "web" / "public" / "test" / "lib" / "prototype" / "prototype.js" ).exists(),
+    (target.value / "web" / "public" / "test" / "lib" / "prototype" / "prototype.js").exists(),
     "Could not find prototype library in test"
   )
 }

--- a/src/sbt-test/sbt-web/extract-web-jars/test
+++ b/src/sbt-test/sbt-web/extract-web-jars/test
@@ -1,12 +1,11 @@
 # Extract everything
 > assets
-$ exists target/web/public/main/lib/jquery/jquery.js
-$ exists target/web/public/main/lib/prototype/prototype.js
--$ exists target/web/public/main/lib/requirejs/require.js
+> fileCheckAssets
 
 # Extract node modules
 > Assets/webNodeModules
 $ exists target/web/node-modules/main/webjars/less/package.json
+> fileCheckNode
 
 > clean
 
@@ -19,7 +18,7 @@ $ touch target/foo
 $ sleep 1000
 > assets
 # jquery.js should not have been re-extracted, assert that it is older
-$ newer target/foo target/web/public/main/lib/jquery/jquery.js
+> checkJqueryTimestamp
 
 > clean
 
@@ -27,11 +26,7 @@ $ newer target/foo target/web/public/main/lib/jquery/jquery.js
 > TestAssets/assets
 
 # All webjars on test classpath are extracted for tests
-$ exists target/web/web-modules/test/webjars/lib/requirejs/require.js
-$ exists target/web/web-modules/test/webjars/lib/jquery/jquery.js
-$ exists target/web/web-modules/test/webjars/lib/prototype/prototype.js
+> checkTestAssets
 
 # Now check everything was aggregated in test assets
-$ exists target/web/public/test/lib/jquery/jquery.js
-$ exists target/web/public/test/lib/prototype/prototype.js
-$ exists target/web/public/test/lib/requirejs/require.js
+> checkTestLibs

--- a/src/sbt-test/sbt-web/extract-web-jars/test
+++ b/src/sbt-test/sbt-web/extract-web-jars/test
@@ -4,7 +4,6 @@
 
 # Extract node modules
 > Assets/webNodeModules
-$ exists target/web/node-modules/main/webjars/less/package.json
 > fileCheckNode
 
 > clean


### PR DESCRIPTION
Adds sbt2 compatibility for some scripted tests.

These tests all work with sbt 1 and 2 crossbuilds:
* asset-pipeline
* dedup
* dev-pipeline
* exclude-hidden-files
* extract-web-jars

Also:
* Adds a convenience `asFile` for future compatibility of additional tests
* Switches all file checks to local tasks. This is because the target directory changes in sbt 2.

Towards #255 