### PR TITLE
Add directory filter compatibility shim

### DIFF
--- a/src/main/scala-2.12/com/typesafe/sbt/PluginCompat.scala
+++ b/src/main/scala-2.12/com/typesafe/sbt/PluginCompat.scala
@@ -2,6 +2,7 @@ package com.typesafe.sbt
 
 import sbt.*
 import sbt.Keys.Classpath
+import com.typesafe.sbt.web.PathMapping
 import xsbti.FileConverter
 
 import java.nio.file.{ Path => NioPath }
@@ -28,4 +29,5 @@ private[sbt] object PluginCompat {
   def toFileRef(f: File)(implicit conv: FileConverter): FileRef = f
   def selectFirstPredicate: Seq[FileRef] => Boolean = files =>
     files.forall(_.isFile) && files.map(_.hashString).distinct.size == 1
+  def fileRefCompatible(path: PathMapping)(implicit conv: FileConverter): Boolean = true
 }

--- a/src/main/scala-3/com/typesafe/sbt/PluginCompat.scala
+++ b/src/main/scala-3/com/typesafe/sbt/PluginCompat.scala
@@ -5,6 +5,7 @@ import java.io.{ File => IoFile }
 import sbt.*
 import sbt.Keys.Classpath
 import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFileRef }
+import com.typesafe.sbt.web.PathMapping
 
 private[sbt] object PluginCompat:
   type FileRef = HashedVirtualFileRef
@@ -30,4 +31,6 @@ private[sbt] object PluginCompat:
     conv.toVirtualFile(file.toPath)
   inline def selectFirstPredicate(using conv: FileConverter): Seq[FileRef] => Boolean = files =>
     files.forall(toFile(_).isFile) && files.map(_.contentHashStr).distinct.size == 1
+  inline def fileRefCompatible(path: PathMapping)(using conv: FileConverter): Boolean =
+    !toFile(path._1).isDirectory
 end PluginCompat


### PR DESCRIPTION
Stacked on top of #261 

Fixes #262.

* Adds `fileRefCompatible` to the compatibility shim, to allow for directory checks only in Scala 3.
* Changes webjar and asset mapping utilities to check for directories using compatibility shims, and filter them out of the resulting `Seq[PathMapping]` value.