### PR TITLE
Cross build with 2.0.0-RC2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ project/plugins/project/
 hs_err_pid*
 
 .sdkmanrc
+.bloop
+.metals
+.vscode
+**/.DS_Store
+**/project/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,9 @@ developers += Developer(
 )
 
 lazy val scala212 = "2.12.20"
-lazy val scala3 = "3.3.4"
-ThisBuild / crossScalaVersions := Seq(scala212)
+lazy val scala3 = "3.7.2"
+ThisBuild / crossScalaVersions := Seq(scala212, scala3)
+ThisBuild / scalaVersion := scala3
 
 libraryDependencies ++= Seq(
   "org.webjars" % "webjars-locator-core" % "0.59",
@@ -29,10 +30,10 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
   s
 }
 
-(pluginCrossBuild / sbtVersion) := {
+ThisBuild / (pluginCrossBuild / sbtVersion) := {
   scalaBinaryVersion.value match {
     case "2.12" => "1.10.2"
-    case _      => "2.0.0-M2"
+    case _      => "2.0.0-RC2"
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ developers += Developer(
 
 lazy val scala212 = "2.12.20"
 lazy val scala3 = "3.7.2"
-ThisBuild / crossScalaVersions := Seq(scala212, scala3)
-ThisBuild / scalaVersion := scala3
+ThisBuild / crossScalaVersions := Seq(scala212)
+ThisBuild / scalaVersion := scala212
 
 libraryDependencies ++= Seq(
   "org.webjars" % "webjars-locator-core" % "0.59",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.3
+sbt.version=1.11.4

--- a/src/main/scala-2.12/com/typesafe/sbt/PluginCompat.scala
+++ b/src/main/scala-2.12/com/typesafe/sbt/PluginCompat.scala
@@ -10,6 +10,10 @@ import java.nio.file.{ Path => NioPath }
 private[sbt] object PluginCompat {
   type FileRef = java.io.File
   type UnhashedFileRef = java.io.File
+  
+  class cacheLevel(include: Array[Any]) extends annotation.StaticAnnotation
+  def uncached[T](value: T): T = value 
+  val TestResultPassed = ()
 
   def toNioPath(a: Attributed[File])(implicit conv: FileConverter): NioPath =
     a.data.toPath

--- a/src/main/scala-2.12/com/typesafe/sbt/PluginCompat.scala
+++ b/src/main/scala-2.12/com/typesafe/sbt/PluginCompat.scala
@@ -10,9 +10,9 @@ import java.nio.file.{ Path => NioPath }
 private[sbt] object PluginCompat {
   type FileRef = java.io.File
   type UnhashedFileRef = java.io.File
-  
+
   class cacheLevel(include: Array[Any]) extends annotation.StaticAnnotation
-  def uncached[T](value: T): T = value 
+  def uncached[T](value: T): T = value
   val TestResultPassed = ()
 
   def toNioPath(a: Attributed[File])(implicit conv: FileConverter): NioPath =

--- a/src/main/scala-3/com/typesafe/sbt/PluginCompat.scala
+++ b/src/main/scala-3/com/typesafe/sbt/PluginCompat.scala
@@ -8,6 +8,11 @@ import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFileRef }
 import com.typesafe.sbt.web.PathMapping
 
 private[sbt] object PluginCompat:
+  export sbt.CacheImplicits.{*, given}
+  export sbt.util.cacheLevel
+  export sbt.Def.uncached
+
+  val TestResultPassed = TestResult.Passed
   type FileRef = HashedVirtualFileRef
   type UnhashedFileRef = VirtualFileRef
 

--- a/src/main/scala-3/com/typesafe/sbt/PluginCompat.scala
+++ b/src/main/scala-3/com/typesafe/sbt/PluginCompat.scala
@@ -8,7 +8,7 @@ import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFileRef }
 import com.typesafe.sbt.web.PathMapping
 
 private[sbt] object PluginCompat:
-  export sbt.CacheImplicits.{*, given}
+  export sbt.CacheImplicits.{ *, given }
   export sbt.util.cacheLevel
   export sbt.Def.uncached
 

--- a/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
@@ -12,7 +12,7 @@ import com.typesafe.sbt.web.pipeline.Pipeline
 import com.typesafe.sbt.web.incremental.{ OpResult, OpSuccess, toStringInputHasher }
 import xsbti.{ Reporter, FileConverter }
 
-import com.typesafe.sbt.PluginCompat.{*, given}
+import com.typesafe.sbt.PluginCompat.{ *, given }
 
 object Import {
 
@@ -263,10 +263,11 @@ object SbtWeb extends AutoPlugin {
     (Test / exportedProductsNoTracking) ++= exportAssets(TestAssets, Test, TrackLevel.NoTracking).value,
     (Assets / compile) := uncached(Analysis.Empty),
     (TestAssets / compile) := uncached(Analysis.Empty),
-    (TestAssets / compile) := uncached{
+    (TestAssets / compile) := uncached {
       (TestAssets / compile).dependsOn(Assets / compile).value
     },
-    (TestAssets / test) := Def.task(TestResultPassed)
+    (TestAssets / test) := Def
+      .task(TestResultPassed)
       .dependsOn(TestAssets / compile)
       .value,
     addWatchSources(unmanagedSources, unmanagedSourceDirectories, Assets),
@@ -275,7 +276,7 @@ object SbtWeb extends AutoPlugin {
     addWatchSources(unmanagedResources, unmanagedResourceDirectories, TestAssets),
     pipelineStages := Seq.empty,
     allPipelineStages := Pipeline.chain(pipelineStages).value,
-    pipeline := uncached{
+    pipeline := uncached {
       allPipelineStages.value((Assets / mappings).value)
     },
     deduplicators := Nil,
@@ -298,10 +299,10 @@ object SbtWeb extends AutoPlugin {
     managedSourceDirectories := Nil,
     managedSources := sourceGenerators(_.join).map(_.flatten).value,
     unmanagedSourceDirectories := Seq(sourceDirectory.value),
-    unmanagedSources := uncached{
+    unmanagedSources := uncached {
       unmanagedSourceDirectories.value
-      .descendantsExcept(includeFilter.value, excludeFilter.value)
-      .get()
+        .descendantsExcept(includeFilter.value, excludeFilter.value)
+        .get()
     },
     sourceDirectories := managedSourceDirectories.value ++ unmanagedSourceDirectories.value,
     sources := managedSources.value ++ unmanagedSources.value,
@@ -310,10 +311,10 @@ object SbtWeb extends AutoPlugin {
     managedResourceDirectories := Nil,
     managedResources := resourceGenerators(_.join).map(_.flatten).value,
     unmanagedResourceDirectories := Seq(resourceDirectory.value),
-    unmanagedResources := uncached{
+    unmanagedResources := uncached {
       unmanagedResourceDirectories.value
-      .descendantsExcept(includeFilter.value, excludeFilter.value)
-      .get()
+        .descendantsExcept(includeFilter.value, excludeFilter.value)
+        .get()
     },
     resourceDirectories := managedResourceDirectories.value ++ unmanagedResourceDirectories.value,
     resources := managedResources.value ++ unmanagedResources.value,

--- a/src/sbt-test/sbt-web/asset-pipeline/project/plugins.sbt
+++ b/src/sbt-test/sbt-web/asset-pipeline/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-web" % sys.props("project.version"))
+Compile / scalacOptions += "-Xmacro-settings:sbt:no-default-task-cache"

--- a/src/sbt-test/sbt-web/deduplicate/project/plugins.sbt
+++ b/src/sbt-test/sbt-web/deduplicate/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-web" % sys.props("project.version"))
+Compile / scalacOptions += "-Xmacro-settings:sbt:no-default-task-cache"

--- a/src/sbt-test/sbt-web/dev-pipeline/project/plugins.sbt
+++ b/src/sbt-test/sbt-web/dev-pipeline/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-web" % sys.props("project.version"))
+Compile / scalacOptions += "-Xmacro-settings:sbt:no-default-task-cache"

--- a/src/sbt-test/sbt-web/multi-module/project/plugins.sbt
+++ b/src/sbt-test/sbt-web/multi-module/project/plugins.sbt
@@ -3,3 +3,4 @@ addSbtPlugin("com.github.sbt" % "sbt-web" % sys.props("project.version"))
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
+Compile / scalacOptions += "-Xmacro-settings:sbt:no-default-task-cache"

--- a/src/sbt-test/sbt-web/package/project/plugins.sbt
+++ b/src/sbt-test/sbt-web/package/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-web" % sys.props("project.version"))
+Compile / scalacOptions += "-Xmacro-settings:sbt:no-default-task-cache"


### PR DESCRIPTION
Fixes compilation issues found when running with 2.0.0-RC2 due to introduction of automatic caching. 
The compiler compat was adjusted to sbt API changes. Most of scripted tests now have disabled automatic caching to allow for cross testing with Sbt 1.0 
The only failing scripted test is still `sbt-web/multi-module`