### PR TITLE
Workaround for `WebKeys.importDirectly` in sbt 2.x

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11, 8
-      scala: 2.12.20
+      scala: 2.12.20, 3.3.4
       cmd: |
         sbt ++$MATRIX_SCALA test scripted
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11, 8
-      scala: 2.12.20, 3.3.4
+      scala: 2.12.20, 3.7.2
       cmd: |
         sbt ++$MATRIX_SCALA test scripted
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ developers += Developer(
 
 lazy val scala212 = "2.12.20"
 lazy val scala3 = "3.3.4"
-ThisBuild / crossScalaVersions := Seq(scala212)
+ThisBuild / crossScalaVersions := Seq(scala212, scala3)
 
 libraryDependencies ++= Seq(
   "org.webjars" % "webjars-locator-core" % "0.59",

--- a/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
+++ b/src/main/scala/com/typesafe/sbt/web/SbtWeb.scala
@@ -251,6 +251,14 @@ object SbtWeb extends AutoPlugin {
         Nil
       }
     },
+    (Test / packageBin / packageOptions) ++= {
+      if (exportJars.value) Some(Package.ManifestAttributes(ModuleNameAttribute -> moduleName.value))
+      else None
+    },
+    (Compile / packageBin / packageOptions) ++= {
+      if (exportJars.value) Some(Package.ManifestAttributes(ModuleNameAttribute -> moduleName.value))
+      else None
+    },
     (Compile / exportedProducts) ++= exportAssets(Assets, Compile, TrackLevel.TrackAlways).value,
     (Test / exportedProducts) ++= exportAssets(TestAssets, Test, TrackLevel.TrackAlways).value,
     (Compile / exportedProductsIfMissing) ++= exportAssets(Assets, Compile, TrackLevel.TrackIfMissing).value,
@@ -464,8 +472,27 @@ object SbtWeb extends AutoPlugin {
    * Get module names for all internal web module dependencies on the classpath.
    */
   def getInternalWebModules(conf: Configuration): Def.Initialize[Task[Seq[String]]] = Def.task {
-    (conf / internalDependencyClasspath).value.flatMap(_.get(toKey(WebKeys.webModulesLib)))
+    implicit val fc: FileConverter = fileConverter.value
+    (conf / internalDependencyClasspath).value
+      .flatMap { entry =>
+        // First, try attribute (sbt 1.x path when exportJars := false)
+        entry
+          .get(toKey(WebKeys.webModulesLib))
+          .orElse {
+            // Fallback for sbt 2.x where exportJars := true by default and the above attribute is missing.
+            val file = toFile(entry.data)
+            if (file.ext != "jar") None
+            else
+              io.Using.jarFile(verify = false)(file) { jar =>
+                for {
+                  manifest <- Option(jar.getManifest())
+                  moduleName <- Option(manifest.getMainAttributes.getValue(ModuleNameAttribute))
+                } yield moduleName
+              }
+          }
+      }
   }
+  private final val ModuleNameAttribute = "Sbt-Web-Module"
 
   /**
    * Remove web module dependencies from a classpath. This is a helper method for Play 2.3 transitions.
@@ -571,7 +598,7 @@ object SbtWeb extends AutoPlugin {
    * Return the result of the first Some returning function.
    */
   private def firstResult[A, B](fs: Seq[A => Option[B]])(a: A): Option[B] = {
-    (fs.toStream flatMap { f => f(a).toSeq }).headOption
+    fs.view.flatMap(_.apply(a).toSeq).headOption
   }
 
   /**


### PR DESCRIPTION
Workaround fix for #263 - maybe there is a better solution, but this approach might unblock cross builds for sbt 2.x. 
In the workaround to `exportJars` problem we store the module name in JAR manifest (yes, this build specific information would leak to published JAR unfortunately). 
Feel free to close the PR if the workaround is conflicting with overall goals of this project. 